### PR TITLE
[Fix] - Mount - Tests correction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ categories = ["science", "simulation"]
 keywords = ["telescope", "astronomy"]
 
 [workspace.dependencies]
-gmt_dos-clients = { version = "2.0.0", default-features = false }
+gmt_dos-clients = { version = "2.0.0", default-features = true }
 gmt-fem = { version = "3.1.1" }
 gmt_dos-actors = { version = "7.0.0", path = "actors/" }
 dos-uid-derive = { version = "2.0.0", path = "actors/uid-derive/" }

--- a/clients/mount/Cargo.toml
+++ b/clients/mount/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 
 [dependencies]
 gmt_dos-actors.workspace = true
-gmt_dos-clients = { workspace = true, features = ["interface"] }
+gmt_dos-clients.workspace = true
 gmt_dos-clients_io.workspace = true
 gmt_dos-clients_fem.workspace = true
 gmt_dos-clients_arrow.workspace = true

--- a/clients/mount/tests/setpoint_mount.rs
+++ b/clients/mount/tests/setpoint_mount.rs
@@ -4,7 +4,8 @@ use gmt_dos_clients_arrow::Arrow;
 use gmt_dos_clients_fem::{DiscreteModalSolver, ExponentialMatrix};
 use gmt_dos_clients_io::{gmt_m1::M1RigidBodyMotions, gmt_m2::M2RigidBodyMotions};
 use gmt_dos_clients_mount::Mount;
-use gmt_fem::{fem_io::*, FEM};
+use gmt_fem::fem_io::actors_outputs::{MCM2Lcl6D, OSSM1Lcl};
+use gmt_fem::FEM;
 use lom::{OpticalMetrics, LOM};
 use skyangle::Conversion;
 

--- a/clients/mount/tests/zero_mount.rs
+++ b/clients/mount/tests/zero_mount.rs
@@ -5,15 +5,14 @@
 //! The FEM model repository is read from the `FEM_REPO` environment variable
 //! The LOM sensitivity matrices are located in the directory given by the `LOM` environment variable
 
-use dos_actors::prelude::*;
-use dos_clients_arrow::Arrow;
-use dos_clients_io::{MountEncoders, MountSetPoint, MountTorques};
-use fem::{
-    dos::{DiscreteModalSolver, ExponentialMatrix},
-    fem_io::*,
-    FEM,
-};
+use gmt_dos_actors::prelude::*;
+use gmt_dos_clients::Signals;
+use gmt_dos_clients_arrow::Arrow;
+use gmt_dos_clients_fem::{DiscreteModalSolver, ExponentialMatrix};
+use gmt_dos_clients_io::{gmt_m1::M1RigidBodyMotions, gmt_m2::M2RigidBodyMotions};
 use gmt_dos_clients_mount::Mount;
+use gmt_fem::fem_io::actors_outputs::{MCM2Lcl6D, OSSM1Lcl};
+use gmt_fem::FEM;
 use lom::{Stats, LOM};
 
 #[tokio::test]
@@ -23,76 +22,50 @@ async fn zero_mount_at() -> anyhow::Result<()> {
     let n_step = sim_sampling_frequency * sim_duration;
 
     let state_space = {
-        let fem = FEM::from_env()?.static_from_env()?;
-        let n_io = (fem.n_inputs(), fem.n_outputs());
+        let fem = FEM::from_env()?;
         DiscreteModalSolver::<ExponentialMatrix>::from_fem(fem)
             .sampling(sim_sampling_frequency as f64)
             .proportional_damping(2. / 100.)
-            .ins::<OSSElDriveTorque>()
-            .ins::<OSSAzDriveTorque>()
-            .ins::<OSSRotDriveTorque>()
-            .outs::<OSSAzEncoderAngle>()
-            .outs::<OSSElEncoderAngle>()
-            .outs::<OSSRotEncoderAngle>()
+            .including_mount()
             .outs::<OSSM1Lcl>()
             .outs::<MCM2Lcl6D>()
-            .use_static_gain_compensation(n_io)
+            .use_static_gain_compensation()
             .build()?
     };
 
-    let mut source: Initiator<_> = Signals::new(3, n_step).into();
+    // SET POINT
+    let mut setpoint: Initiator<_> = Signals::new(3, n_step).into();
     // FEM
     let mut fem: Actor<_> = state_space.into();
     // MOUNT
-    let mut mount: Actor<_> = Mount::new().into();
-
+    let mount: Actor<_> = Mount::builder(&mut setpoint).build(&mut fem)?;
+    
     let logging = Arrow::builder(n_step).build().into_arcx();
     let mut sink = Terminator::<_>::new(logging.clone());
 
-    source
-        .add_output()
-        .build::<MountSetPoint>()
-        .into_input(&mut mount);
-    mount
-        .add_output()
-        .build::<MountTorques>()
-        .into_input(&mut fem);
-    fem.add_output()
-        .bootstrap()
-        .multiplex(2)
-        .build::<MountEncoders>()
-        .into_input(&mut mount)
-        .logn(&mut sink, 14)
-        .await;
     fem.add_output()
         .unbounded()
-        .build::<OSSM1Lcl>()
-        .logn(&mut sink, 42)
-        .await;
+        .build::<M1RigidBodyMotions>()
+        .log(&mut sink)
+        .await?;
     fem.add_output()
         .unbounded()
-        .build::<MCM2Lcl6D>()
-        .logn(&mut sink, 42)
-        .await;
+        .build::<M2RigidBodyMotions>()
+        .log(&mut sink)
+        .await?;
 
-    Model::new(vec![
-        Box::new(source),
-        Box::new(mount),
-        Box::new(fem),
-        Box::new(sink),
-    ])
-    .name("mount")
-    .flowchart()
-    .check()?
-    .run()
-    .wait()
-    .await?;
+    model!(setpoint, mount, fem, sink)
+        .check()?
+        .flowchart()
+        .run()
+        .wait()
+        .await?;
 
     let lom = LOM::builder()
         .rigid_body_motions_record(
             (*logging.lock().await).record()?,
-            Some("OSSM1Lcl"),
-            Some("MCM2Lcl6D"),
+            Some("M1RigidBodyMotions"),
+            Some("M2RigidBodyMotions"),
         )?
         .build()?;
     let tiptilt = lom.tiptilt_mas();


### PR DESCRIPTION
## Problem

Both tests for the mount client were not working due to latest changes. The main issue seemed to be around importing and code that was deprecated. 

## Solution

Here it is proposed the solution of adjusting the necessary crates to be imported with needed configurations and also refactor the current code to support new versions of clients.

> Don't know how is the main impact of this change outside the mount tests environment, please be sure to review for possible global impacts.