### PR TITLE
Facesheet Options

### DIFF
--- a/clients/fem/src/impl_serde.rs
+++ b/clients/fem/src/impl_serde.rs
@@ -3,13 +3,15 @@ use std::{
     io::{BufReader, BufWriter},
 };
 
-use crate::{DiscreteModalSolver, Solver};
+use crate::{DiscreteModalSolver, Solver, StateSpaceError};
+
+type Result<T> = std::result::Result<T, StateSpaceError>;
 
 impl<T> DiscreteModalSolver<T>
 where
     T: Solver + Default + serde::Serialize + for<'a> serde::Deserialize<'a>,
 {
-    pub fn save<P>(&self, path: P) -> crate::Result<&Self>
+    pub fn save<P>(&self, path: P) -> Result<&Self>
     where
         P: AsRef<std::path::Path> + std::fmt::Debug,
     {
@@ -29,7 +31,7 @@ where
     T: Solver + Default + serde::Serialize + for<'a> serde::Deserialize<'a>,
 {
     type Error = crate::StateSpaceError;
-    fn try_from(path: String) -> crate::Result<Self> {
+    fn try_from(path: String) -> Result<Self> {
         let path =
             std::path::Path::new(&env::var("DATA_REPO").unwrap_or_else(|_| String::from(".")))
                 .join(&path);
@@ -46,7 +48,7 @@ where
     T: Solver + Default + serde::Serialize + for<'a> serde::Deserialize<'a>,
 {
     type Error = crate::StateSpaceError;
-    fn try_from(path: &str) -> crate::Result<Self> {
+    fn try_from(path: &str) -> Result<Self> {
         let path =
             std::path::Path::new(&env::var("DATA_REPO").unwrap_or_else(|_| String::from(".")))
                 .join(&path);
@@ -63,7 +65,7 @@ where
     T: Solver + Default + serde::Serialize + for<'a> serde::Deserialize<'a>,
 {
     type Error = crate::StateSpaceError;
-    fn try_from(path: std::path::PathBuf) -> crate::Result<Self> {
+    fn try_from(path: std::path::PathBuf) -> Result<Self> {
         let path =
             std::path::Path::new(&env::var("DATA_REPO").unwrap_or_else(|_| String::from(".")))
                 .join(&path);

--- a/clients/servos/examples/m2-rbms/main.rs
+++ b/clients/servos/examples/m2-rbms/main.rs
@@ -31,12 +31,22 @@ use gmt_dos_actors::actorscript;
 use gmt_dos_clients::Tick;
 use gmt_dos_clients::{Signals, Timer};
 use gmt_dos_clients_io::gmt_m2::{asm::segment::FaceSheetFigure, M2RigidBodyMotions};
-use gmt_dos_clients_servos::{AsmsServo, GmtFem};
+use gmt_dos_clients_servos::{AsmsServo, GmtFem}; //asms_servo
 use gmt_dos_clients_servos::{GmtM2Hex, GmtServoMechanisms};
 use gmt_fem::FEM;
 use nanorand::{Rng, WyRand};
 
-const ACTUATOR_RATE: usize = 80;
+const ACTUATOR_RATE: usize = 80; //100Hz
+
+/*
+#[derive(Debug, Clone)]
+struct MyFacesheet;
+impl asms_servo::FacesheetOptions for MyFacesheet {
+    fn remove_rigid_body_motions(&self) -> bool {
+        false
+    }
+}
+*/
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -65,11 +75,20 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // GMT Servo-mechanisms system
+    
     let gmt_servos =
         GmtServoMechanisms::<ACTUATOR_RATE, 1>::new(sim_sampling_frequency as f64, fem)
             .asms_servo(AsmsServo::new().facesheet(Default::default()))
             .build()?;
-
+    /*
+    let gmt_servos = GmtServoMechanisms::<ACTUATOR_RATE, 1>::new(sim_sampling_frequency as f64, fem)
+            .asms_servo(AsmsServo::new().facesheet(
+                    asms_servo::Facesheet::new()
+                        .options(Box::new(MyFacesheet))
+                ),
+            )
+            .build()?;
+    */
     actorscript! {
         1: m2_rbm[M2RigidBodyMotions] -> {gmt_servos::GmtM2Hex}
     }


### PR DESCRIPTION
 I add to remove the facesheet flag for  turning on/off the RBMs removal as it was breaking the `gmt_dos-clients_servos` crate upstream,
I introduce instead a public trait `FacesheetOptions` to customize the facesheet:
```
use gmt_dos_clients_servos::{asms_servo, AsmsServo, GmtServoMechanisms};
use gmt_fem::FEM;

const ACTUATOR_RATE: usize = 80; // 100Hz

#[derive(Debug, Clone)]
struct MyFacesheet;
impl asms_servo::FacesheetOptions for MyFacesheet {
    fn remove_rigid_body_motions(&self) -> bool {
        false
    }
}

let frequency = 8000_f64; // Hz
let fem = FEM::from_env()?;

let gmt_servos =
    GmtServoMechanisms::<ACTUATOR_RATE, 1>::new(frequency, fem)
        .asms_servo(
            AsmsServo::new().facesheet(
                asms_servo::Facesheet::new()
                    .options(Box::new(MyFacesheet))
            ),
        )
        .build()?;
```
