### PR TITLE
CUDA FEATURE

### DIFF
--- a/clients/fem/Cargo.toml
+++ b/clients/fem/Cargo.toml
@@ -30,7 +30,7 @@ geotrans = "0.2.2"
 toml = {version = "0.8.19", optional = true}
 faer.workspace = true
 faer-ext.workspace = true
-fem-cuda-solver = { version = "0.1.0", path = "fem-cuda-solver" }
+fem-cuda-solver = { version = "0.1.0", path = "fem-cuda-solver", optional = true}
 
 [build-dependencies]
 anyhow.workspace = true
@@ -49,6 +49,7 @@ serde = [
     "bincode/serde",
     "nalgebra/serde-serialize",
 ]
+cuda = ["dep:fem-cuda-solver"]
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/clients/fem/src/discrete_modal_solver.rs
+++ b/clients/fem/src/discrete_modal_solver.rs
@@ -1,7 +1,7 @@
 use crate::{
     actors_interface::RbmRemoval,
     fem_io::{GetIn, GetOut},
-    solvers::{CuStateSpace, Exponential, ExponentialMatrix, Solver},
+    solvers::{Exponential, ExponentialMatrix, Solver},
     DiscreteStateSpace,
 };
 
@@ -153,15 +153,6 @@ impl Iterator for DiscreteModalSolver<ExponentialMatrix> {
         }
 
         Some(())
-    }
-}
-impl Iterator for DiscreteModalSolver<CuStateSpace> {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.state_space
-            .get_mut(0)
-            .map(|ss| ss.step(&mut self.u, &mut self.y))
     }
 }
 impl<T: Solver + Default> fmt::Display for DiscreteModalSolver<T> {

--- a/clients/fem/src/discrete_state_space.rs
+++ b/clients/fem/src/discrete_state_space.rs
@@ -2,7 +2,6 @@ use crate::{
     actors_interface::RbmRemoval,
     fem_io::{FemIo, GetIn, GetOut, SplitFem},
     solvers::Solver,
-    DiscreteModalSolver,
 };
 
 use gmt_fem::{fem_io::Inputs, fem_io::Outputs, FEM};
@@ -597,13 +596,5 @@ impl<'a, T: Solver + Default> DiscreteStateSpace<'a, T> {
                 "Failed to build both modal transformation matrices".to_string(),
             )),
         }
-    }
-}
-
-impl<'a, S: Solver + Default> TryFrom<DiscreteStateSpace<'a, S>> for DiscreteModalSolver<S> {
-    type Error = StateSpaceError;
-
-    fn try_from(dss: DiscreteStateSpace<'a, S>) -> std::result::Result<Self, Self::Error> {
-        dss.build()
     }
 }

--- a/clients/fem/src/lib.rs
+++ b/clients/fem/src/lib.rs
@@ -11,13 +11,25 @@
 //! A single input and a single output are selected.
 //! ```no_run
 //! use gmt_fem::FEM;
-//! use gmt_dos_clients_fem::{DiscreteStateSpace, DiscreteModalSolver, solvers::Exponential,
+//! use gmt_dos_clients_fem::{DiscreteStateSpace, DiscreteModalSolver,
 //!               fem_io::{actors_inputs::OSSM1Lcl6F, actors_outputs::OSSM1Lcl}};
+//! #[cfg(not(feature = "cuda"))]
+//! use gmt_dos_clients_fem::solvers::Exponential;
+//! #[cfg(feature = "cuda")]
+//! use gmt_dos_clients_fem::solvers::{CuStateSpace, Exponential};
 //!
 //! # fn main() -> anyhow::Result<()> {
 //!     let sampling_rate = 1e3; // Hz
 //!     let fem = FEM::from_env()?;
+//!   #[cfg(not(feature = "cuda"))]
 //!     let mut fem_ss: DiscreteModalSolver<Exponential> = DiscreteStateSpace::from(fem)
+//!         .sampling(sampling_rate)
+//!         .proportional_damping(2. / 100.)
+//!         .ins::<OSSM1Lcl6F>()
+//!         .outs::<OSSM1Lcl>()
+//!         .build()?;
+//!   #[cfg(feature = "cuda")]
+//!     let mut fem_ss: DiscreteModalSolver<CuStateSpace> = DiscreteStateSpace::<Exponential>::from(fem)
 //!         .sampling(sampling_rate)
 //!         .proportional_damping(2. / 100.)
 //!         .ins::<OSSM1Lcl6F>()

--- a/clients/fem/src/solvers.rs
+++ b/clients/fem/src/solvers.rs
@@ -1,10 +1,12 @@
 mod bilinear;
+#[cfg(feature = "cuda")]
 mod cuda_solver;
 mod exponential;
 mod exponential_matrix;
 
 pub use bilinear::Bilinear;
-pub use cuda_solver::CuStateSpace;
+#[cfg(feature = "cuda")]
+pub use cuda_solver::{CuStateSpace, ModeStateSpace};
 pub use exponential::Exponential;
 pub use exponential_matrix::ExponentialMatrix;
 

--- a/clients/servos/Cargo.toml
+++ b/clients/servos/Cargo.toml
@@ -44,5 +44,8 @@ gmt_dos-clients_scope = { workspace = true, features = ["server"] }
 gmt_dos-clients_scope-client.workspace = true
 nanorand.workspace = true
 
+[features]
+cuda = ["gmt_dos-clients_fem/cuda"]
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fem)'] }

--- a/clients/servos/src/builder/asms_servo/facesheet.rs
+++ b/clients/servos/src/builder/asms_servo/facesheet.rs
@@ -13,6 +13,7 @@ use std::{
 
 use crate::builder::Include;
 
+
 #[derive(Debug, thiserror::Error)]
 pub enum FacesheetError {
     #[error("Failed to get Matlab ")]

--- a/clients/servos/src/builder/edge_sensors.rs
+++ b/clients/servos/src/builder/edge_sensors.rs
@@ -1,5 +1,8 @@
-use gmt_dos_clients_fem::fem_io::actors_outputs::{M2EdgeSensors, OSSM1EdgeSensors};
-use gmt_dos_clients_fem::{solvers::ExponentialMatrix, DiscreteStateSpace};
+use gmt_dos_clients_fem::{
+    fem_io::actors_outputs::{M2EdgeSensors, OSSM1EdgeSensors},
+    solvers::ExponentialMatrix,
+    DiscreteStateSpace,
+};
 use nalgebra as na;
 
 use super::Include;

--- a/clients/servos/src/lib.rs
+++ b/clients/servos/src/lib.rs
@@ -83,6 +83,11 @@ mod fem {
     pub use crate::servos::GmtServoMechanisms;
     use gmt_dos_actors::system::Sys;
 
+    #[cfg(not(feature = "cuda"))]
+    pub(crate) type FemSolver = gmt_dos_clients_fem::solvers::ExponentialMatrix;
+    #[cfg(feature = "cuda")]
+    pub(crate) type FemSolver = gmt_dos_clients_fem::solvers::CuStateSpace;
+
     /// GMT servo-mechanisms system
     // pub enum GmtServoMechanisms<const M1_RATE: usize, const M2_RATE: usize = 1> {}
 
@@ -118,8 +123,7 @@ mod fem {
     }
 
     /// GMT FEM client
-    pub type GmtFem =
-        gmt_dos_clients_fem::DiscreteModalSolver<gmt_dos_clients_fem::solvers::ExponentialMatrix>;
+    pub type GmtFem = gmt_dos_clients_fem::DiscreteModalSolver<FemSolver>;
     /// GMT M1 client
     pub type GmtM1 = gmt_dos_clients_m1_ctrl::assembly::DispatchIn;
     /// GMT mount client

--- a/clients/servos/src/servos.rs
+++ b/clients/servos/src/servos.rs
@@ -7,7 +7,7 @@ use gmt_dos_actors::{
     prelude::Actor,
     system::{Sys, System},
 };
-use gmt_dos_clients_fem::{solvers::ExponentialMatrix, DiscreteModalSolver};
+use gmt_dos_clients_fem::DiscreteModalSolver;
 use gmt_dos_clients_io::{
     gmt_m1::assembly,
     gmt_m2::{
@@ -22,12 +22,14 @@ use gmt_dos_clients_mount::Mount;
 
 use serde::{Deserialize, Serialize};
 
+use crate::FemSolver;
+
 pub mod io;
 pub mod traits;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct GmtServoMechanisms<const M1_RATE: usize, const M2_RATE: usize = 1> {
-    pub fem: Actor<DiscreteModalSolver<ExponentialMatrix>>,
+    pub fem: Actor<DiscreteModalSolver<FemSolver>>,
     pub mount: Actor<Mount>,
     pub m1: Sys<M1<M1_RATE>>,
     pub m2_positioners: Actor<AsmsPositioners>,

--- a/clients/servos/src/servos/io.rs
+++ b/clients/servos/src/servos/io.rs
@@ -2,28 +2,26 @@ use gmt_dos_actors::{
     prelude::Actor,
     system::{SystemInput, SystemOutput},
 };
-use gmt_dos_clients_fem::{solvers::ExponentialMatrix, DiscreteModalSolver};
+use gmt_dos_clients_fem::DiscreteModalSolver;
 
 use gmt_dos_clients_m2_ctrl::AsmsPositioners;
 use gmt_dos_clients_mount::Mount;
 
-use super::GmtServoMechanisms;
+use super::{FemSolver, GmtServoMechanisms};
 
 // FEM inputs
-impl<const M1_RATE: usize, const M2_RATE: usize>
-    SystemInput<DiscreteModalSolver<ExponentialMatrix>, 1, 1>
+impl<const M1_RATE: usize, const M2_RATE: usize> SystemInput<DiscreteModalSolver<FemSolver>, 1, 1>
     for GmtServoMechanisms<M1_RATE, M2_RATE>
 {
-    fn input(&mut self) -> &mut Actor<DiscreteModalSolver<ExponentialMatrix>, 1, 1> {
+    fn input(&mut self) -> &mut Actor<DiscreteModalSolver<FemSolver>, 1, 1> {
         &mut self.fem
     }
 }
 // FEM outputs
-impl<const M1_RATE: usize, const M2_RATE: usize>
-    SystemOutput<DiscreteModalSolver<ExponentialMatrix>, 1, 1>
+impl<const M1_RATE: usize, const M2_RATE: usize> SystemOutput<DiscreteModalSolver<FemSolver>, 1, 1>
     for GmtServoMechanisms<M1_RATE, M2_RATE>
 {
-    fn output(&mut self) -> &mut Actor<DiscreteModalSolver<ExponentialMatrix>, 1, 1> {
+    fn output(&mut self) -> &mut Actor<DiscreteModalSolver<FemSolver>, 1, 1> {
         &mut self.fem
     }
 }

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -30,3 +30,6 @@ gmt_dos-clients_windloads.workspace = true
 interface.workspace = true
 skyangle.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+
+[features]
+cuda = ["gmt_dos-clients_fem/cuda", "gmt_dos-clients_servos/cuda"]

--- a/demos/src/bin/windloaded-mount-m1-asms/main.rs
+++ b/demos/src/bin/windloaded-mount-m1-asms/main.rs
@@ -89,8 +89,7 @@ async fn main() -> anyhow::Result<()> {
             .outs::<MCM2SmHexD>()
             .outs::<MCM2RB6D>()
             .use_static_gain_compensation()
-            .build()?
-            .with_cuda_solver();
+            .build()?;
     println!("{state_space}");
 
     // SET POINT

--- a/demos/src/bin/windloaded-mount-m1/main.rs
+++ b/demos/src/bin/windloaded-mount-m1/main.rs
@@ -72,8 +72,7 @@ async fn main() -> anyhow::Result<()> {
             .outs::<MCM2Lcl6D>()
             .outs::<MCM2RB6D>()
             .use_static_gain_compensation()
-            .build()?
-            .with_cuda_solver();
+            .build()?;
     println!("{state_space}");
 
     // SET POINT

--- a/demos/src/bin/windloaded-mount/main.rs
+++ b/demos/src/bin/windloaded-mount/main.rs
@@ -81,8 +81,7 @@ async fn main() -> anyhow::Result<()> {
             .outs::<MCM2Lcl6D>()
             .outs::<MCM2RB6D>()
             .use_static_gain_compensation()
-            .build()?
-            .with_cuda_solver();
+            .build()?;
     println!("{state_space}");
 
     // SET POINT


### PR DESCRIPTION
Add `cuda` feature to `gmt_dos-clients_fem` to enable the use of the FEM CUDA solver.
As both the `gmt_dos-clients_servos` and `demos` crates depends on `gmt_dos-clients_fem`, a `cuda` feature is also available to them both to enable the same feature in `gmt_dos-clients_fem`.
To run one of the `demos` binary using the FEM CUDA solver, it suffices to invoke the `cuda`  feature:
```
cargo r -r --bin windloaded-mount-m1-asms  --features cuda
```